### PR TITLE
fix variables field so it mounts as env

### DIFF
--- a/charts/genero/Chart.yaml
+++ b/charts/genero/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: genero
-version: v1.0.0
-appVersion: v1.0.0
+version: v1.0.1
+appVersion: v1.0.1
 description: Genero, a generic best practice ci/cd helm chart
 home: https://polymatic.systems
 keywords:

--- a/charts/genero/templates/cronjob.yml
+++ b/charts/genero/templates/cronjob.yml
@@ -151,17 +151,18 @@ spec:
               runAsUser: 0
             {{- end }}
               privileged: {{ if $cntr.privileged }}{{ "true" }}{{ else }}{{ "false "}}{{ end }}
-            {{- if or $v.config $v.secret }}
+            {{- if $v.variables }}
             envFrom:
-              {{- range $v.config }}
+              {{- range $v.variables }}
+                {{- if eq (.store | default "") "plaintext" }}
               - configMapRef:
                   name: {{ include "name" $ }}-{{ .name }}
                   optional: false
-              {{- end }}
-              {{- range $v.secret }}
+                {{- else }}
               - secretRef:
                   name: {{ include "name" $ }}-{{ .name }}
                   optional: false
+                {{- end }}
               {{- end }}
             {{- end }}
             {{- if $v.volumes }}

--- a/charts/genero/templates/deploy.yml
+++ b/charts/genero/templates/deploy.yml
@@ -1,6 +1,5 @@
 {{- $default := .Values.default -}}
-{{- $config := .Values.config -}}
-{{- $secret := .Values.secret -}}
+{{- $variables := .Values.variables -}}
 {{- $volumes := .Values.volumes -}}
 {{- $deploy := .Values.deploy | default dict }}
 {{- if and .Values.containers (not .Values.cronjobs) }}
@@ -111,17 +110,18 @@ spec:
           runAsUser: 0
         {{- end }}
           privileged: {{ ternary "true" "false" (.privileged | default false) }}
-        {{- if or $config $secret }}
+        {{- if $variables }}
         envFrom:
-          {{- range $config }}
+          {{- range $variables }}
+            {{- if eq (.store | default "") "plaintext" }}
           - configMapRef:
               name: {{ include "name" $ }}-{{ .name }}
               optional: false
-          {{- end }}
-          {{- range $secret }}
+            {{- else }}
           - secretRef:
               name: {{ include "name" $ }}-{{ .name }}
               optional: false
+            {{- end }}
           {{- end }}
         {{- end }}
       {{- end }}
@@ -188,17 +188,18 @@ spec:
           runAsUser: 0
         {{- end }}
           privileged: {{ ternary "true" "false" (.privileged | default false) }}
-        {{- if or $config $secret }}
+        {{- if or $variables }}
         envFrom:
-          {{- range $config }}
+          {{- range $variables }}
+            {{- if eq (.store | default "") "plaintext" }}
           - configMapRef:
               name: {{ include "name" $ }}-{{ .name }}
               optional: false
-          {{- end }}
-          {{- range $secret }}
+            {{- else }}
           - secretRef:
               name: {{ include "name" $ }}-{{ .name }}
               optional: false
+            {{- end }}
           {{- end }}
         {{- end }}
         {{- if $volumes }}

--- a/tests/cronjobs.values.yml
+++ b/tests/cronjobs.values.yml
@@ -12,7 +12,7 @@ default:
 name: helmet
 version: "2020"
 
-config:
+variables:
 - name: configuration
   data:
     TEST: data

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -18,7 +18,7 @@ if [[ -n "$1" ]]; then
   
   trap "rm values.yml; exit 0;" HUP INT QUIT ABRT TERM ERR
 
-  helm upgrade ${1} ../app \
+  helm upgrade ${1} ../charts/genero  \
     --namespace helmspace \
     --values values.yml \
     --dry-run --install;
@@ -31,11 +31,11 @@ else
 
     trap "rm values.yml; exit 0;" HUP INT QUIT ABRT TERM ERR
 
-    # helm template test ../app \
+    # helm template test ../charts/genero  \
     #   --namespace helmspace \
     #   --values values.yml --validate
     
-    helm upgrade ${filename%%.*} ../app \
+    helm upgrade ${filename%%.*} ../charts/genero  \
       --namespace helmspace \
       --values values.yml \
       --dry-run --install;

--- a/tests/unusual.values.yml
+++ b/tests/unusual.values.yml
@@ -14,18 +14,17 @@ default:
 
 volumes:
 - name: cv
-  path: /app/.env
+  path: /app
   file: .env
   data:
     .env: |
       SERVER_PORT: 3000
 
-config:
+variables:
 - name: config
+  store: plaintext
   data:
     TEST_SECRET: "${TEST_SECRET}"
-
-secret:
 - name: secret
   data:
     TEST_CONFIG: "${TEST_CONFIG}"


### PR DESCRIPTION
this is a fix that ensures the variables field actually mounts configmaps and secrets as environment variables into deployments and cronjobs.