### PR TITLE
adds option to destroy the pvc on uninstall

### DIFF
--- a/charts/genero/Chart.yaml
+++ b/charts/genero/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: genero
-version: v1.2.1
-appVersion: v1.2.1
+version: v1.2.2
+appVersion: v1.2.2
 description: Genero, a generic best practice ci/cd helm chart
 home: https://polymatic.systems
 keywords:

--- a/charts/genero/templates/volumes.yml
+++ b/charts/genero/templates/volumes.yml
@@ -16,7 +16,9 @@ metadata:
   name: {{ include "name" $ }}-{{ .name }}
   namespace: {{ include "ns" $ }}
   annotations:
+    {{- if eq (.perpetual | default "enable") "enable" }}
     "helm.sh/resource-policy": keep
+    {{- end }}
 spec:
   {{- if .pvc.class }}
   storageClassName: {{ .pvc.class }}

--- a/charts/genero/values.schema.json
+++ b/charts/genero/values.schema.json
@@ -354,6 +354,9 @@
           "path": {
             "type": "string"
           },
+          "perpetual": {
+            "type": "string"
+          },
           "file": {
             "type": "string"
           },

--- a/charts/genero/values.schema.json
+++ b/charts/genero/values.schema.json
@@ -355,7 +355,8 @@
             "type": "string"
           },
           "perpetual": {
-            "type": "string"
+            "type": "string",
+            "enum": ["enable", "disable"]
           },
           "file": {
             "type": "string"

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -25,6 +25,7 @@ volumes:
 - name:
   path:
   file: 
+  perpetual: 'enable' ('enable', 'disable')
   data:
 ```
 
@@ -49,6 +50,7 @@ volumes: <- this set up is for mounting file volumes
 - name: an arbitrary name
   path: the directory path to mount the volume
   file: if the volume is a file, put the file name here
+  perpetual: whether to retain the pvc if the release is uninstalled
   data:
     file.name: |
       placing a yaml multiline string here will create a secret instead of a volume and mount it as a file

--- a/tests/unusual.values.yml
+++ b/tests/unusual.values.yml
@@ -19,6 +19,12 @@ volumes:
   data:
     .env: |
       SERVER_PORT: 3000
+- name: data
+  path: /data
+  perpetual: "disable"
+  pvc:
+    class: pg1
+    size: 10Gi
 
 variables:
 - name: config


### PR DESCRIPTION
option is labeled: perpetual.

can be either: disable or enable. default to enable.