### PR TITLE
Do not mount service account token if RBAC is not needed

### DIFF
--- a/charts/genero/templates/sa.yml
+++ b/charts/genero/templates/sa.yml
@@ -4,5 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ include "name" $ }}
   namespace: {{ include "ns" $ }}
+{{- if not .Values.rbac }}
+automountServiceAccountToken: false
+{{- end }}
 ---
 {{- end }}

--- a/docs/cronjobs.md
+++ b/docs/cronjobs.md
@@ -5,12 +5,13 @@ If `cronjobs` field is set, then cronjobs will be deployed instead of a deployme
 
 Any of the "global" values can be overridden in each cronjob definition.
 
-The following values can be overwritten on the first container in each cronjob definition: `command`, `args`, `resources`.
+The following values can be overwritten on the first container in each cronjob definition: `entrypoint`, `command`, `resources`.
 
 ```yaml
 # default settings
 cronjobs:
-- schedule:
+- name:
+  schedule:
   concurrency: 'Allow' ('Allow', 'Forbid', 'Replace')
   suspend: false
   retries: 3
@@ -21,7 +22,8 @@ cronjobs:
 # explanations
 
 cronjobs:
-- schedule: the cron schedule for the job
+- name: the name of the cronjob
+  schedule: the cron schedule for the job
   concurrency: allow concurrent runs of the cronjob, forbid them, or force new jobs to replace old ones
   suspend: disable this cronjob, can be used for creating on-demand jobs
   retries: number of retries to attempt on failed jobs

--- a/tests/unusual.values.yml
+++ b/tests/unusual.values.yml
@@ -69,7 +69,8 @@ annotations:
   random: "value"
 
 nodes:
-  network: 'private'
+  force: 
+    status: 'private'
 
 mesh: false
 registry: false


### PR DESCRIPTION
Removes service account token from pods if RBAC is not enabled.